### PR TITLE
DRILL: optimize site access speed for some regions

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,13 +7,12 @@
 <title>{% if page.title %}{{ page.title }} - {{ site.title_suffix }}{% else %}{{ site.title }}{% endif %}</title>
 
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css"/>
-<link href='https://fonts.googleapis.com/css?family=PT+Sans' rel='stylesheet' type='text/css'/>
 <link href="{{ site.baseurl }}/css/site.css" rel="stylesheet" type="text/css"/>
 
 <link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico" type="image/x-icon"/>
 <link rel="icon" href="{{ site.baseurl }}/favicon.ico" type="image/x-icon"/>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" language="javascript" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js" language="javascript" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js" language="javascript" type="text/javascript"></script>
 <script language="javascript" type="text/javascript" src="{{ site.baseurl }}/js/modernizr.custom.js"></script>
 <script language="javascript" type="text/javascript" src="{{ site.baseurl }}/js/script.js"></script>

--- a/css/site.scss
+++ b/css/site.scss
@@ -1,5 +1,39 @@
 ---
 ---
+
+/* cyrillic-ext */
+@font-face {
+        font-family: 'PT Sans';
+        font-style: normal;
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/s/ptsans/v12/jizaRExUiTo99u79D0-ExcOPIDUg-g.woff2) format('woff2');
+        unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+        font-family: 'PT Sans';
+        font-style: normal;
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/s/ptsans/v12/jizaRExUiTo99u79D0aExcOPIDUg-g.woff2) format('woff2');
+        unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* latin-ext */
+@font-face {
+        font-family: 'PT Sans';
+        font-style: normal;
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/s/ptsans/v12/jizaRExUiTo99u79D0yExcOPIDUg-g.woff2) format('woff2');
+        unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+        font-family: 'PT Sans';
+        font-style: normal;
+        font-weight: 400;
+        src: url(https://fonts.gstatic.com/s/ptsans/v12/jizaRExUiTo99u79D0KExcOPIDU.woff2) format('woff2');
+        unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
 @import "site-main",
         "site-responsive",
         "site-search",


### PR DESCRIPTION
# DRILL: optimize site access speed for some regions

## Description

Due to some regions access visit google directly, visit drill site slowly in those regions.

Localize the css content which get from google's URL before.

And change the source of jquery.min.js from Google to  Gloudflare.

## Documentation

Similar optimization please refer to https://github.com/apache/drill/pull/2395

## Testing

Start-up drill-site locally, the site loads normally and renders faster obviously.