### PR TITLE
DRILL-7579: documentation of Initial Admin Identity for all drill interfaces

### DIFF
--- a/_docs/en/configure-drill/securing-drill/030-roles-privileges.md
+++ b/_docs/en/configure-drill/securing-drill/030-roles-privileges.md
@@ -36,6 +36,8 @@ To configure an initial Admin User and Group add an `security.admin` configurati
 
 Set the value of this options to a comma-separated list of user or group names who you want to give administrator privileges, such as changing system options.
 
+The groups in `security.admin.user_groups` refer to groups in the configured Hadoop group mapping service which defaults to looking up local operating system groups. See [Hadoop Groups Mapping](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/GroupsMapping.html) for more information.
+
 See [Configuring Web UI and REST API Security]({{site.baseurl}}/docs/configuring-web-console-and-rest-api-security/) for more information.
 
 

--- a/_docs/en/configure-drill/securing-drill/030-roles-privileges.md
+++ b/_docs/en/configure-drill/securing-drill/030-roles-privileges.md
@@ -22,6 +22,20 @@ When authentication is enabled, only Drill users who are assigned Drill cluster 
 - View profiles of all queries that all users have run or are currently running in a cluster.
 - Cancel running queries that were launched by any user in the cluster.
 
+### Initial Admin Identity
+
+To configure an initial Admin User and Group add an `security.admin` configuration entry like below into your `drill-override.conf` .
+
+    drill.exec: {
+        ...
+    },
+    security.admin: {
+        users: "drill",
+        user_groups: "hadoop"
+    }
+
+Set the value of this options to a comma-separated list of user or group names who you want to give administrator privileges, such as changing system options.
+
 See [Configuring Web UI and REST API Security]({{site.baseurl}}/docs/configuring-web-console-and-rest-api-security/) for more information.
 
 


### PR DESCRIPTION
[DRILL-7579](https://issues.apache.org/jira/browse/DRILL-7579 ) requests a better documentation of the Initial Admin Identity.

These PR extends the documentation for an Initial Admin Identity within `drill-override.conf` 