### PR TITLE
Remove spam links

### DIFF
--- a/_docs/en/install/047-installing-drill-on-the-cluster.md
+++ b/_docs/en/install/047-installing-drill-on-the-cluster.md
@@ -8,9 +8,7 @@ You install Drill on nodes in the cluster, configure a cluster ID, and add Zooke
 
 ### Install
 
-1. Download the latest version of Apache Drill [here](http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) or from the [Apache Drill mirror site](http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) with the command appropriate for your system:
-   - `wget http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
-   - `curl -o apache-drill-1.19.0.tar.gz http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
+1. [Download the latest version of Apache Drill](https://drill.apache.org/download/)
 2. Extract the tarball to the directory of your choice, such as `/opt`:
    `tar -xf apache-drill-<version>.tar.gz`
 

--- a/_docs/en/install/installing-drill-in-embedded-mode/020-installing-drill-on-linux-and-mac-os-x.md
+++ b/_docs/en/install/installing-drill-in-embedded-mode/020-installing-drill-on-linux-and-mac-os-x.md
@@ -8,9 +8,7 @@ First, check that you [meet the prerequisites]({{site.baseurl}}/docs/embedded-mo
 Complete the following steps to install Drill:
 
 1. In a terminal window, change to the directory where you want to install Drill.
-2. Download the latest version of Apache Drill [here](http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) or from the [Apache Drill mirror site](http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) with the command appropriate for your system:
-       * `wget http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
-       * `curl -o apache-drill-1.19.0.tar.gz http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
+2. [Download the latest version of Apache Drill](https://drill.apache.org/download/)
 3. Copy the downloaded file to the directory where you want to install Drill.
 4. Extract the contents of the Drill `.tar.gz` file. Use sudo only if necessary:
 `tar -xvzf <.tar.gz file name>`


### PR DESCRIPTION
The linked download mirror is now a spam site. 

Also remove link to a specific download version. Having a specific download version in the docs can create ongoing maintenance work. 