### PR TITLE
remove spam site from 10 minute tutorial

### DIFF
--- a/_docs/en/tutorials/020-drill-in-10-minutes.md
+++ b/_docs/en/tutorials/020-drill-in-10-minutes.md
@@ -45,9 +45,7 @@ The output looks something like this:
 Complete the following steps to install Drill:
 
 1. In a terminal window, change to the directory where you want to install Drill.
-2. Download the latest version of Apache Drill from the [Apache Drill mirror site](http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) with the command appropriate for your system:
-       * `wget http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
-       * `curl -o apache-drill-1.19.0.tar.gz http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
+2. [Download the latest version of Apache Drill](https://drill.apache.org/download/)
 3. Copy the downloaded file to the directory where you want to install Drill.
 4. Extract the contents of the Drill .tar.gz file. Use `sudo` if necessary:
 `tar -xvzf <.tar.gz file name>`

--- a/_docs/en/tutorials/020-drill-in-10-minutes.md
+++ b/_docs/en/tutorials/020-drill-in-10-minutes.md
@@ -45,9 +45,9 @@ The output looks something like this:
 Complete the following steps to install Drill:
 
 1. In a terminal window, change to the directory where you want to install Drill.
-2. Download the latest version of Apache Drill [here](http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) or from the [Apache Drill mirror site](http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) with the command appropriate for your system:
-       * `wget http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
-       * `curl -o apache-drill-1.19.0.tar.gz http://apache.mirrors.hoobly.com/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
+2. Download the latest version of Apache Drill from the [Apache Drill mirror site](http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz) with the command appropriate for your system:
+       * `wget http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
+       * `curl -o apache-drill-1.19.0.tar.gz http://www.apache.org/dyn/closer.cgi/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz`
 3. Copy the downloaded file to the directory where you want to install Drill.
 4. Extract the contents of the Drill .tar.gz file. Use `sudo` if necessary:
 `tar -xvzf <.tar.gz file name>`


### PR DESCRIPTION
Going through the [10 minute tutorial](https://drill.apache.org/docs/drill-in-10-minutes/), and discovered the first linked download mirror is now a spam site.

Removing, following the pattern in https://github.com/apache/drill-site/pull/36