### PR TITLE
Update 040-installing-drill-on-windows.md

### DIFF
--- a/_docs/en/install/installing-drill-in-embedded-mode/040-installing-drill-on-windows.md
+++ b/_docs/en/install/installing-drill-in-embedded-mode/040-installing-drill-on-windows.md
@@ -49,7 +49,7 @@ You, or the user that will start Drill, must manually create and own UDF directo
 
 ## Download and Install Drill
 
-1. Download the latest version of Apache Drill [here](http://www-us.apache.org/dist/drill/drill-1.19.0/apache-drill-1.19.0.tar.gz).
+1. Download the latest version of Apache Drill [here](https://drill.apache.org/download/).
 2. Move the downloaded file to the directory where you want to install Drill.
 3. Unzip the GZ file using a third-party tool. If the tool you use does not unzip the underlying TAR file as well as the GZ file, perform a second unzip to extract the Drill software. The extraction process creates the installation directory containing the Drill software.
 4. [Start Drill]({{site.baseurl}}/docs/starting-drill-on-windows).


### PR DESCRIPTION
Current download link points to an older version of Drill & is broken. Updating link to point to the Downloads page instead