### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,16 @@
 <p class="push"></p>
 <div id="footer" class="mw">
 <div class="wrapper">
-Copyright © 2012-2025 The Apache Software Foundation, licensed under the Apache License, Version 2.0.<br>
-Apache and the Apache feather logo are trademarks of The Apache Software Foundation. Other names appearing on the site may be trademarks of their respective owners.<br/><br/>
+Copyright © 2012-2026 The Apache Software Foundation, licensed under the
+<a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.<br>
+Apache Drill, Drill, Apache, the Apache feather logo, and the Apache Drill project logo are either
+registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.<br><br>
+<a href="https://www.apache.org/">Foundation</a> |
+<a href="https://www.apache.org/events/current-event.html">Events</a> |
+<a href="https://www.apache.org/licenses/">License</a> |
+<a href="https://www.apache.org/security/">Security</a> |
+<a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+<a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+<a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
 </div>
 </div>


### PR DESCRIPTION
The Drill website is missing links required by ASF website policy (https://whimsy.apache.org/site/):

- Foundation link (apache.org)
- Events
- License (was text-only, now linked)
- Security
- Sponsorship
- Thanks
- Privacy

Also updates copyright year to 2026 and improves the trademark statement to specifically mention Apache Drill.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/