### PR TITLE
Add AGENTS.md + SECURITY.md pointing to the Drill security model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/legal/release-policy.html -->
+
+# Agent Guide for drill-site
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+This repository is the Apache Drill project website; the project's security model lives in the main apache/drill repository, linked below.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/legal/release-policy.html -->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/drill-site` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in <https://github.com/apache/drill/blob/master/THREAT_MODEL.md>.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or
discuss as needed.** Nothing here is a requirement; the maintainer is the
decision-maker.

This adds a minimal `AGENTS.md` + `SECURITY.md` to the Drill website repo so
an automated scan agent can mechanically discover the project's security model
via the conventional `AGENTS.md → SECURITY.md → threat model` chain.

`apache/drill-site` is the project website; the actual security model lives in
the main `apache/drill` repository, so these files just **point** there (the
project's umbrella model) rather than duplicating it. Nothing about the model
content changes — this is only the discoverability wiring.

Context: the ASF Security team is preparing the project for an automated
agentic security scan we're piloting. Such scans refuse to run if the model
isn't discoverable by that path (refusing upfront beats a noise-heavy run
against a model the agent never found). This is the website-repo companion to
the model that already merged on `apache/drill`; wiring the site repo too
means the full requested scope is discoverable.

Questions / pushback welcome — happy to adjust the wording, or to drop the
site repo from scope entirely if you'd rather not include it in the scan.
